### PR TITLE
Mass message delete and message delete refactor

### DIFF
--- a/dialect.loki.js
+++ b/dialect.loki.js
@@ -625,7 +625,7 @@ const getMessages = (ids) => {
         // check our permission
         if (!msg || !msg.user) {
           // not even on the list
-          console.log('no message or user object', msg);
+          console.warn('no message or user object', msg);
           const resObj={
             meta: {
               code: 500,
@@ -638,7 +638,7 @@ const getMessages = (ids) => {
         }
         if (msg.user.id !== usertoken.userid) {
           // not even on the list
-          console.log('user', usertoken.userid, 'tried to delete', msg.user.id, 'message', msg);
+          console.warn('user', usertoken.userid, 'tried to delete users', msg.user.id, 'message', msg.id);
           const resObj={
             meta: {
               code: 403,
@@ -721,7 +721,7 @@ const modTryDeleteMessages = (ids, access_list) => {
 
   app.delete(prefix + '/loki/v1/moderation/messages', (req, res) => {
     if (!req.query.ids) {
-      console.log('moderation message mass delete ids empty');
+      console.warn('moderation message mass delete ids empty');
       res.status(422).type('application/json').end(JSON.stringify({
         error: 'ids missing',
       }));
@@ -735,7 +735,7 @@ const modTryDeleteMessages = (ids, access_list) => {
       ids = [ ids ];
     }
     if (ids.length > 200) {
-      console.log('moderation message mass delete too many ids, 200<', ids.length);
+      console.warn('moderation message mass delete too many ids, 200<', ids.length);
       res.status(422).type('application/json').end(JSON.stringify({
         error: 'too many ids',
       }));

--- a/dialect.loki.js
+++ b/dialect.loki.js
@@ -675,9 +675,20 @@ const getMessages = (ids) => {
 const modTryDeleteMessages = (ids, access_list) => {
   return new Promise(async (resolve, rej) => {
     const [ code, err, messages ] = await getMessages(ids);
+    if (err) {
+      const resObj = {
+        meta: {
+          code,
+          request: ids,
+          err
+        },
+        data: messages
+      };
+      return resolve(resObj);
+    }
     const metas = [];
     const datas = [];
-    await Promise.all(messages.map(async (msg) => {
+    await Promise.all(messages.map(async (message) => {
       // handle already deleted messages
       if (!message || message.is_deleted) {
         const resObj={

--- a/dialect.loki.js
+++ b/dialect.loki.js
@@ -573,7 +573,6 @@ const getMessages = (ids) => {
         console.error('getMessage err', getErr);
         return resolve([500, getErr, false]);
       }
-
       if (!messages || !messages.length) {
         return resolve([410, 'no messages', false]);
       }
@@ -610,7 +609,7 @@ const getMessages = (ids) => {
     }
     validUser(req.token, res, async usertoken => {
       const [ code, err, messages ] = await getMessages(ids);
-      //console.log('user multidelete getMessages result', code, err, messages.length)
+      console.log('user multidelete getMessages result', code, err, messages.length)
       if (err) {
         const resObj = {
           meta: {
@@ -721,7 +720,7 @@ const modTryDeleteMessages = (ids, access_list) => {
       resObj.meta.id = message.id;
       // ok how do we want to aggregate these results...
       metas.push(resObj.meta);
-      datas.push(resObj.meta);
+      datas.push(resObj.data);
     }));
     resObj = {
       meta: {

--- a/test/test.js
+++ b/test/test.js
@@ -215,6 +215,7 @@ function create_message(channelId) {
             text: 'testing message',
           },
         });
+        //console.log('create message result', result, 'token', platformApi.token);
         assert.equal(200, result.statusCode);
         resolve(result.response.data.id);
       //});
@@ -276,6 +277,52 @@ function mod_delete_message(channelId, messageId) {
   });
 }
 
+function mod_multi_delete_message(channelId, messages) {
+  return new Promise((resolve, rej) => {
+    describe("modDelete message /loki/v1/moderation/messages?ids="+messages.join(','), async () =>{
+      //it("returns status code 200", async () => {
+        // test delete endpoint
+        const result = await overlayApi.serverRequest('loki/v1/moderation/messages', {
+          method: 'DELETE',
+          params: {
+            ids: messages.join(',')
+          }
+        });
+        assert.equal(200, result.statusCode);
+        //console.log('modDelete message body', body);
+        // {"meta":{"code":200},"data":{
+        // "user_id":10,"client_id":"messenger",
+        //"scopes":"basic stream write_post follow messages update_profile files export",
+        //"created_at":"2019-09-09T01:15:06.000Z","expires_at":"2019-09-09T02:15:06.000Z"}}
+        resolve();
+      });
+    //});
+  });
+}
+
+function multi_delete_message(channelId, messages) {
+  return new Promise((resolve, rej) => {
+    describe("delete message /loki/v1/messages?ids="+messages.join(','), async () =>{
+      //it("returns status code 200", async () => {
+        // test delete endpoint
+        const result = await overlayApi.serverRequest('loki/v1/messages', {
+          method: 'DELETE',
+          params: {
+            ids: messages.join(',')
+          }
+        });
+        assert.equal(200, result.statusCode);
+        //console.log('delete message body', body);
+        // {"meta":{"code":200},"data":{
+        // "user_id":10,"client_id":"messenger",
+        //"scopes":"basic stream write_post follow messages update_profile files export",
+        //"created_at":"2019-09-09T01:15:06.000Z","expires_at":"2019-09-09T02:15:06.000Z"}}
+        resolve();
+      });
+    //});
+  });
+}
+
 const runIntegrationTests = async (ourKey, ourPubKeyHex) => {
   describe('ensurePlatformServer', async () => {
     it('make sure we have something to storage with', async () => {
@@ -287,7 +334,7 @@ const runIntegrationTests = async (ourKey, ourPubKeyHex) => {
       await ensureOverlayServer();
     });
   });
-  let channelId = 3; // default channel to try to test first
+  let channelId = 1; // default channel to try to test first
 
   // get our token
   let tokenString
@@ -332,15 +379,33 @@ const runIntegrationTests = async (ourKey, ourPubKeyHex) => {
         }
         overlayApi.token = modToken;
       });
-      let messageId
+      let messageId, messageId1, messageId2, messageId3, messageId4
       it('create message to test with', async () => {
         // well we need to create a new message for moderation test
         messageId = await create_message(channelId);
+        messageId1 = await create_message(channelId);
+        messageId2 = await create_message(channelId);
+        messageId3 = await create_message(channelId);
+        messageId4 = await create_message(channelId);
         //console.log('messageId', messageId);
       });
       it('mod delete test', async () => {
         if (modToken && messageId) {
           await mod_delete_message(channelId, messageId);
+        }
+      });
+      it('mod multi delete test', async () => {
+        if (modToken && messageId1 && messageId2) {
+          await mod_multi_delete_message(channelId, [messageId1, messageId2]);
+        } else {
+          console.log('skipping')
+        }
+      });
+      it('user multi delete test', async () => {
+        if (messageId3 && messageId4) {
+          await multi_delete_message(channelId, [messageId3, messageId4]);
+        } else {
+          console.log('skipping')
         }
       });
       it('can get deletes for channel', () => {

--- a/test/test.js
+++ b/test/test.js
@@ -358,7 +358,7 @@ const runIntegrationTests = async (ourKey, ourPubKeyHex) => {
     });
 
     // make sure we have a channel to test with
-    describe(`channel testing`, () => {
+    describe('channel testing', () => {
       it('make sure we have a channel to test', async () => {
         const chnlCheck = await get_channel(channelId);
         if (Array.isArray(chnlCheck)) {
@@ -366,18 +366,6 @@ const runIntegrationTests = async (ourKey, ourPubKeyHex) => {
           channelId = await admin_create_channel();
           console.log('created channel', channelId);
         }
-      });
-      let modToken
-      it('we have moderator to test with', async () => {
-        // now do moderation tests
-        modToken = await selectModToken();
-        if (!modToken) {
-          console.error('No modToken, skipping moderation tests');
-          // all tests should be complete
-          //process.exit(0);
-          return;
-        }
-        overlayApi.token = modToken;
       });
       let messageId, messageId1, messageId2, messageId3, messageId4
       it('create message to test with', async () => {
@@ -388,18 +376,6 @@ const runIntegrationTests = async (ourKey, ourPubKeyHex) => {
         messageId3 = await create_message(channelId);
         messageId4 = await create_message(channelId);
         //console.log('messageId', messageId);
-      });
-      it('mod delete test', async () => {
-        if (modToken && messageId) {
-          await mod_delete_message(channelId, messageId);
-        }
-      });
-      it('mod multi delete test', async () => {
-        if (modToken && messageId1 && messageId2) {
-          await mod_multi_delete_message(channelId, [messageId1, messageId2]);
-        } else {
-          console.log('skipping')
-        }
       });
       it('user multi delete test', async () => {
         if (messageId3 && messageId4) {
@@ -413,6 +389,33 @@ const runIntegrationTests = async (ourKey, ourPubKeyHex) => {
       });
       it('can get moderators for channel', () => {
         get_moderators(channelId);
+      });
+      // Moderator only functions
+      describe('channel moderator testing', () => {
+        let modToken
+        it('we have moderator to test with', async () => {
+          // now do moderation tests
+          modToken = await selectModToken();
+          if (!modToken) {
+            console.error('No modToken, skipping moderation tests');
+            // all tests should be complete
+            //process.exit(0);
+            return;
+          }
+          overlayApi.token = modToken;
+        });
+        it('mod delete test', async () => {
+          if (modToken && messageId) {
+            await mod_delete_message(channelId, messageId);
+          }
+        });
+        it('mod multi delete test', async () => {
+          if (modToken && messageId1 && messageId2) {
+            await mod_multi_delete_message(channelId, [messageId1, messageId2]);
+          } else {
+            console.log('skipping')
+          }
+        });
       });
     });
   });


### PR DESCRIPTION
/loki/v1/moderation/messages?ids=1,2,3

```
{
  meta: {
    code: 200,
    request: [1,2,3],
    results: [{ meta obj }...],
  },
  data: [
     {
       id: 1,
       is_delete: true,
     },
     ...
  ],
}
```

- may want to change to /loki/moderation/messages/v1?ids=1,2,3 (version by endpoint, so we can change/upgrade them individually)
~~- could promisify more~~
- added `DELETE /loki/v1/messages?ids=1,2,3`
- some test fixing