### PR TITLE
Reporting endpoint stubs

### DIFF
--- a/dialects/moderation/dialect.loki_moderation.js
+++ b/dialects/moderation/dialect.loki_moderation.js
@@ -11,6 +11,10 @@ module.exports = (app, prefix) => {
   utilities.nconf = app.nconf;
   handlers.setup(utilities);
 
+  // Token: User
+  app.post(prefix + '/loki/v1/channels/:channelid/messages/:id/report', handlers.reportMessageHandler);
+  app.post(prefix + '/loki/v1/channels/messages/:id/report', handlers.reportMessageHandler);
+
   // get list of moderators per channel
   // legacy
   app.get(prefix + '/loki/v1/channel/:id/get_moderators', handlers.getChannelModeratorsHandler);
@@ -18,7 +22,6 @@ module.exports = (app, prefix) => {
   app.get(prefix + '/loki/v1/channels/:id/moderators', handlers.getChannelModeratorsHandler);
 
   app.put(prefix + '/loki/v1/channels/:id', handlers.moderatorUpdateChannel);
-
 
   // get a list of deletes in a channel
   // backwards compatibility

--- a/dialects/moderation/dialect_moderation_handlers.js
+++ b/dialects/moderation/dialect_moderation_handlers.js
@@ -358,6 +358,16 @@ const unblacklistUserFromServerHandler = async (req, res) => {
   });
 }
 
+const reportMessageHandler = async (req, res) => {
+  const resObj = {
+    meta: {
+      code: 200
+    },
+    data: []
+  }
+  dialect.sendResponse(resObj, res);
+}
+
 module.exports = {
   setup,
   getChannelModeratorsHandler,
@@ -370,4 +380,5 @@ module.exports = {
   removeGlobalModerator,
   blacklistUserFromServerHandler,
   unblacklistUserFromServerHandler,
+  reportMessageHandler,
 };


### PR DESCRIPTION
New open group reporting endpoints:
```
  app.post(prefix + '/loki/v1/channels/:channelid/messages/:id/report', handlers.reportMessageHandler);
  app.post(prefix + '/loki/v1/channels/messages/:id/report', handlers.reportMessageHandler);
```
 on chat-dev now
both do the same exact thing (just hard to match the existing style, so just mapped both)

will just return `{"meta":{"code":200},"data":[]}` for now